### PR TITLE
Feature/logger

### DIFF
--- a/HTTPSearch/logger.py
+++ b/HTTPSearch/logger.py
@@ -1,0 +1,10 @@
+import logging
+from logging.handlers import RotatingFileHandler
+import sys
+
+log = logging
+log.basicConfig(
+        handlers=[RotatingFileHandler('HTTPSearch.log', maxBytes=2000000, backupCount=7),
+                  log.StreamHandler(sys.stdout)],
+        format="%(asctime)s | %(levelname)s | %(message)s")
+log.root.setLevel(logging.NOTSET)


### PR DESCRIPTION
This logger has a 'log' object that can be imported and shared between all files in an application. 
This can be done with the statement 'from logger import log' in each file. This will log to both the console for testing purposes, and to a file. 
The file is a rolled log, which rolls over every time the log file reaches 2mb. 
The format for rolled logs is 'HTTPSearch.log.X', where X is an ascending number (e.g. 'HTTPSearch.log' is current log and HTTPSearch.log.1 is the previous log). 
A maximum of 7 log files are kept. 